### PR TITLE
Adjust target of user service

### DIFF
--- a/extras/midi-control.service
+++ b/extras/midi-control.service
@@ -6,4 +6,4 @@ Type=simple
 ExecStart=/usr/bin/midi-control
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target

--- a/src/midi_control/action_handlers.py
+++ b/src/midi_control/action_handlers.py
@@ -145,7 +145,8 @@ class FaderCommandAction(ActionHandler):
             check_type = self.options["check"]["type"]
             minv = self.options["min"]
             maxv = self.options["max"]
-            result = max(min(int(checkers[check_type](self.options)), maxv),
+            check_val = checkers[check_type](self.options).strip()
+            result = max(min(int(check_val if check_val else 0), maxv),
                          minv)
             final = int(round((result - minv) / maxv * 127, 0))
             for fader in self.options.get("states", []):

--- a/src/midi_control/checkers.py
+++ b/src/midi_control/checkers.py
@@ -23,7 +23,7 @@ def command_checker(options):
         options["check"]["command"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        check=False
+        check=False,
     ).stdout.decode("UTF-8")
 
 

--- a/src/midi_control/checkers.py
+++ b/src/midi_control/checkers.py
@@ -23,6 +23,7 @@ def command_checker(options):
         options["check"]["command"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        check=False
     ).stdout.decode("UTF-8")
 
 
@@ -40,7 +41,7 @@ def dbus_checker(options):
             res = bool(res)
         return res
 
-    except DBusException as e:
-        log.info("Could not create dbus proxy in dbus action: %s"
-                 % e.get_dbus_message())
+    except DBusException as err:
+        log.info("Could not create dbus proxy in dbus action: %s",
+                 err.get_dbus_message())
         return None


### PR DESCRIPTION
multi-user.target is not available for user services.
Changed to default.target

Also catch errors in command checker

Running "playerctl status" early, when no player was running crashed the whole service